### PR TITLE
Warn about tmux version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ It features multi-server support as well as user listing
 and notifications when users attach/detach.
 
 ## How To Install
+  **IMPORTANT**: Wemux required tmux version >= 1.6
+  
 ### Homebrew (on OS X)
   If you have [Homebrew](http://mxcl.github.com/homebrew/) installed you can
   install wemux with a fairly simple:


### PR DESCRIPTION
older versions of tmux change permissions of /tmp/wemux-wemux  and client is not able to connect.
