### PR TITLE
Add usage for "join" without an argument

### DIFF
--- a/wemux
+++ b/wemux
@@ -373,6 +373,7 @@ host_mode() {
     echo ""
     if [ "$allow_server_change" == "true" ]; then
       echo "    [j] join [name]: Join the specified wemux server."
+      echo "    [j]        join: Display the current wemux server."
       echo "    [d]       reset: Join default wemux server: $default_server_name"
       if [ "$allow_server_list" == "true" ]; then
         echo "    [l]        list: List all currently active wemux servers."
@@ -521,6 +522,7 @@ client_mode() {
     echo ""
     if [ "$allow_server_change" == "true" ]; then
       echo "    [j] join [name]: Join the specified wemux server."
+      echo "    [j]        join: Display the current wemux server."
       echo "    [d]       reset: Join default wemux server: $default_server_name"
       if [ "$allow_server_list" == "true" ]; then
         echo "    [l]        list: List all currently active wemux servers."


### PR DESCRIPTION
When we were using `wemux` today, we wanted to know what the current server was.  However, we didn't see an option for this in `wemux help`.  I looked into it (thinking it would be a good feature addition), but then found out that `wemux join` without an argument did what we wanted.  So I documented it.  :smile:

Thanks for maintaining `wemux`!

Ben
