### PR TITLE
Fix user group detection

### DIFF
--- a/wemux
+++ b/wemux
@@ -696,7 +696,8 @@ user_is_a_host() {
   # If the user is not in the host list, check their groups
   user_groups="$(groups_for_user)";
   for group in ${host_groups[@]}; do
-    if [[ $user_groups =~ " $group " ]]; then
+    group_re="\\b${group}\\b"
+    if [[ $user_groups =~ $group_re ]]; then
       return 0
     fi
   done


### PR DESCRIPTION
There was a slight error in #43 with how it searched the groups. This caused the script to not detect groups at the beginning or end of the list due to whitespace matches.

I have a PR inbound that fixes this by using a regex instead.
