### PR TITLE
Return an error exit status from client commands that fail

### DIFF
--- a/wemux
+++ b/wemux
@@ -325,9 +325,10 @@ announce_connection() {
   [ "$announce_attach" == "true" ] && redirect=`$wemux display-message \
     "$username has attached in $connection_type mode." 2>&1`
   $attach_commands
+  status=$?
   [ "$announce_attach" == "true" ] && redirect=`$wemux display-message \
     "$username has detached." 2>&1`
-  return 0
+  return $status
 }
 
 # Announces when a user joins/changes their server.
@@ -520,6 +521,7 @@ client_mode() {
       $wemux attach -t $server -r
     else
       echo "No wemux server to mirror on '$server'."
+      return 126
     fi
   }
 
@@ -530,6 +532,7 @@ client_mode() {
         $wemux attach -t $server
       else
         echo "No wemux server to pair with on '$server'."
+        return 126
       fi
     else
       echo "Pair mode is disabled."
@@ -551,6 +554,7 @@ client_mode() {
         $wemux attach -t $client_session
       else
         echo "No wemux server to go 'rogue' with on '$server'."
+        return 126
       fi
     else
       echo "Rogue mode is disabled."
@@ -568,6 +572,7 @@ client_mode() {
         echo "Logged out of rogue mode on '$server'."
       else
         echo "No wemux server to log out of on '$server'."
+        return 126
       fi
     else
       echo "Rogue mode is disabled."
@@ -598,6 +603,7 @@ client_mode() {
       announce_connection "mirror" $wemux attach -t $server -r
     else
       echo "No wemux server to attach to on '$server'"
+      return 126
     fi
   }
 


### PR DESCRIPTION
Commands like `wemux pair` should exit with a non-zero status when the command
fails.  In my specific use case, .bash_profile attempts to attach to wemux, if
running, and falls back to a different command if not running.

```
$ wemux pair
No wemux server to pair with on 'wemux'.
$ echo $?
126
```

I believe this patch covers all the client commands. I haven't looked at the
server commands, so you may want to do that own your own.
