### PR TITLE
Use symbolic chmod permissions to obey umask.

### DIFF
--- a/wemux
+++ b/wemux
@@ -382,7 +382,7 @@ host_mode() {
     if ! session_exists; then
       $wemux new-session -d -s $server
       # Open tmux socket to all users to allow clients to connect.
-      chmod 1777 $socket
+      chmod +trwx $socket
       echo "wemux server started on '$server'."
     fi
     reattach


### PR DESCRIPTION
I prefer `o-rwx` on the socket and this allows me to set `umask 007` to accomplish this automatically.