### PR TITLE
Modify kill host command to forcibly remove socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ and notifications when users attach/detach.
 #### wemux attach
   Use `wemux attach` to attach to an existing wemux server.
 #### wemux stop
-  Use `wemux stop` to kill the wemux server and remove the /tmp/wemux-wemux
+  Use `wemux stop` to stop the wemux server and remove the /tmp/wemux-wemux
   socket.
+#### wemux kill
+  Use `wemux kill` to stop the wemux server and forcibly remove the 
+  /tmp/wemux-wemux socket (using sudo).
 #### wemux kick *username*
   Use `wemux kick <username>` to kick an SSH user from the server and remove
   their wemux rogue sessions.

--- a/man/wemux.1
+++ b/man/wemux.1
@@ -22,6 +22,9 @@ WEMUX HOST COMMANDS
 \fBwemux stop\fR
 .
 .br
+\fBwemux kill\fR
+.
+.br
 \fBwemux users\fR
 .
 .br
@@ -83,7 +86,10 @@ Start a wemux session, chmod /tmp/wemux\-wemux to 1777 so that other users may c
 Attach to an existing wemux session\.
 .
 .SS "wemux stop"
-Kill the wemux session and remove the /tmp/wemux\-wemux socket\.
+Stop the wemux session and remove the /tmp/wemux\-wemux socket\.
+.
+.SS "wemux kill"
+Stop the wemux session and forcibly remove the /tmp/wemux\-wemux socket (using sudo)\.
 .
 .SS "wemux kick <var>username</var>"
 Kick an SSH user from the server and remove their wemux pair sessions\.

--- a/wemux
+++ b/wemux
@@ -20,6 +20,7 @@
 # wemux start : Start the wemux server/join an existing wemux server.
 # wemux attach: Join an existing wemux server.
 # wemux stop  : Stop the wemux server.
+# wemux kill  : Stop the wemux server, forcibly killing the socket (with sudo).
 # wemux users : List the currently attached wemux users.
 # wemux kick  : Disconnect an SSH user, remove their wemux server.
 # wemux config: Open the wemux configuration file in your $EDITOR.
@@ -377,6 +378,23 @@ display_version() {
 
 # Host mode, used when user is listed in the host_list array in /usr/local/etc/wemux.conf
 host_mode() {
+  # Sets server and socket vars by a server's name or list number (specified as args)
+  get_server_socket() {
+    server_sockets=(`echo $socket_prefix*`)
+    # If a specific server is supplied:
+    if [ $1 ]; then
+      # If user enters a number, get the server with that number in `wemux list`
+      if [[ $@ =~ ^[0-9]+$ ]]; then
+        socket=${server_sockets[$1-1]}
+        server=`echo $socket | sed -e "s,$socket_prefix-,,g"`
+      # Otherwise, get the server with the supplied name.
+      else
+        server=`sanitize_server_name $@`
+        socket="$socket_prefix-$server"
+      fi
+    fi
+  }
+
   # Start the server if it doesn't exist, otherwise reattach.
   start_server() {
     if ! session_exists; then
@@ -418,21 +436,20 @@ host_mode() {
     fi
   }
 
-  # Stop the wemux session and remove the socket file.
-  stop_server() {
-    server_sockets=(`echo $socket_prefix*`)
-    # If a specific server is supplied:
-    if [ $1 ]; then
-      # If user enters a number, stop the server with that number in `wemux list`
-      if [[ $@ =~ ^[0-9]+$ ]]; then
-        socket=${server_sockets[$1-1]}
-        server=`echo $socket | sed -e "s,$socket_prefix-,,g"`
-      # Otherwise, stop the server with the supplied name.
-      else
-        server=`sanitize_server_name $@`
-        socket="$socket_prefix-$server"
+  # Attempt to take ownership of the server socket
+  steal_socket() {
+    get_server_socket "$@"
+    # If the socket file exists:
+    if [ -e "$socket" ]; then
+      if ! sudo chown $username $socket; then
+        echo "Could not assume ownership of '$socket'."
       fi
     fi
+  }
+
+  # Stop the wemux session and remove the socket file.
+  stop_server() {
+    get_server_socket "$@"
     # If the user doesn't pass an argument, stop current server.
     if kill_server_successful; then
       echo "wemux server on '$server' stopped."
@@ -459,7 +476,8 @@ host_mode() {
     echo ""
     echo "    [s]       start: Start the wemux server/attach to an existing wemux server."
     echo "    [a]      attach: Attach to an existing wemux server."
-    echo "    [k]        stop: Kill the wemux server '$server', delete its socket."
+    echo "    [st]       stop: Stop the wemux server '$server', delete its socket."
+    echo "    [k]        kill: Kill the wemux server '$server', forcibly delete its socket (with sudo)."
     echo ""
     if [ "$allow_server_change" == "true" ]; then
       echo "    [j] join [name]: Join the specified wemux server."
@@ -490,7 +508,7 @@ host_mode() {
       start|s)        announce_connection "host" start_server;;
       attach|a)       announce_connection "host" reattach;;
       stop|st)        shift; stop_server "$@";;
-      kill|k)         shift; stop_server "$@";;
+      kill|k)         shift; steal_socket "$@"; stop_server "$@";;
       help|h)         display_host_commands;;
       join|j)         shift; change_server "$@";;
       name|n)         shift; change_server "$@";;


### PR DESCRIPTION
In a configuration where multiple users can host wemux, suppose user foo starts a wemux session and then ends the tmux session without using `wemux stop` (say, by closing all tmux windows). In this scenario, the wemux socket will be left as something like...
`srw-rw-rw- 1 foo foo 0 Sep 6 10:55 wemux-wemux=`
... and another user, baz, won't be able to successfully run `wemux start` because the server isn't running and foo owns the socket. If baz has sudo access, baz can `sudo chown baz /tmp/wemux/wemux` and then remove it.

The wemux script currently responds to both `wemux stop` and `wemux kill` by calling the `stop_server` function. In this PR, we differentiate `wemux kill` by attempting to forcibly change the ownership of the socket (using sudo, as above) before calling `stop_server`. This is convenient in a multi-tenant compute instance and should help ease some frustration when colleagues forget to cleanly stop the wemux session.