### PR TITLE
Respect configuration in $HOME/etc/wemux.conf

### DIFF
--- a/wemux
+++ b/wemux
@@ -69,6 +69,7 @@ editor=${EDITOR:="vi"}
 
 # Load configuration options from /usr/local/etc/wemux.conf
 [ -f /usr/local/etc/wemux.conf ] && . /usr/local/etc/wemux.conf
+[ -f $HOME/etc/wemux.conf ] && . $HOME/etc/wemux.conf
 
 # Sanitize server name, replace spaces and underscores with dashes.
 # Remove all non alpha-numeric characters, convert to lowercase.


### PR DESCRIPTION
This commit changes wemux to also read configuration from the home directory for when users have no write access to `/usr/local/etc/`.

In the future it might be useful to add an option (e.g. `-c`) to let users define other locations.